### PR TITLE
Add android tor build script

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,30 +26,12 @@ Android platform supports (ICS 4.x or android-15)
 
 Be sure that you have all of the git submodules up-to-date:
 
-	git submodule update --init --recursive
+	./tor-droid-make.sh fetch
 
-To begin building, from the Orbot root directory, you first need to build all
-external C/native dependencies:
+To begin building, from the Orbot root directory, it builds all submodules and
+the project.
 
-	export ANDROID_NDK_HOME={PATH TO YOUR NDK INSTALL}
-	make -C external
-
-At this point, you'll have Tor and Polipo binaries that can be run on an
-Android handset.  You can verify the ARM binary was properly built using the
-following command:
-
-	file external/bin/tor external/bin/polipo
-	
-You should see something like:
-    external/bin/tor: ELF 32-bit LSB executable, ARM, version 1 (SYSV),
-        dynamically linked (uses shared libs), not stripped
-    external/bin/polipo: ELF 32-bit LSB executable, ARM, version 1 (SYSV),
-        dynamically linked (uses shared libs), not stripped
-
-This isn't enough though and we'll now sew up the binary into a small package
-that will handle basic Tor controlling features.
-
-	android update project --name Orbot --target android-15 --path .
+        ./tor-droid-make.sh build
 
 Now build the Android app
 

--- a/tor-droid-make.sh
+++ b/tor-droid-make.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -e
+
+fetch_submodules()
+{
+    if [ -n "$1" ]; then
+        echo "Cleaning repository"
+        git reset --hard
+        git clean -fdx
+        git submodule foreach git reset --hard
+        git submodule foreach git clean -fdx
+    fi
+    echo "Fetching git submodules"
+    git submodule sync
+    git submodule foreach git submodule sync
+    git submodule update --init --recursive
+}
+
+check_android_dependencies()
+{
+    if [ -z $ANDROID_HOME ]; then
+        echo "ANDROID_HOME must be set!"
+        exit
+    fi
+
+    if [ -z $ANDROID_NDK_HOME ]; then
+        echo "ANDROID_NDK_HOME not set and 'ndk-build' not in PATH"
+        exit
+    fi
+}
+
+build_external_dependencies()
+{
+    check_android_dependencies
+    make -C external
+}
+
+build_app()
+{
+    echo "Building Orfox"
+    build_external_dependencies
+    $ANDROID_HOME/tools/android update project --name $2 --target $3 --path ./tor-android-binary/src/main/
+
+    if [ -z $1 ] || [ $1 = 'debug' ]; then
+        ./gradlew assembleDebug
+    else
+        ./gradlew assembleRelease
+    fi
+}
+
+show_options()
+{
+    echo "usage: ./orbot-tools.sh command arguments"
+    echo ""
+    echo "Commands:"
+    echo "          fetch   Fetch git submodules"
+    echo "          build   Build the project"
+    echo ""
+    echo "Options:"
+    echo "          -b      Build type, it can be release or debug (default: debug)"
+    echo "          -c      Clean the repository (Used together with the fetch command)"
+    echo "          -n      Project name (default: Orbot)"
+    echo "          -t      Project target (default: android-23)"
+    echo ""
+    exit
+}
+
+option=$1
+build_type="debug"
+name="Orbot"
+target="android-23"
+
+if [ -z $option ]; then
+    show_options
+fi
+shift
+
+while getopts 'c:b:n:t' opts; do
+    case $opts in
+        c) clean=clean ;;
+        b) build_type=${OPTARG:-$build_type} ;;
+        n) name=${OPTARG:-$Orbot} ;;
+        t) target=${OPTARG:-$target} ;;
+    esac
+done
+
+case "$option" in
+    "fetch") fetch_submodules $clean ;;
+    "build") build_app $build_type $name $target ;;
+    *) show_options ;;
+esac


### PR DESCRIPTION
It is used to help the developer to fetch and build the app.
Initially, three commands were add:
1. fetch: It fetches the external dependencies
2. build: Build the project in release or debug mode