### PR TITLE
use --disable-samples introduced in libevent 2.1.5

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -163,7 +163,6 @@ openssl-clean:
 # libevent
 
 libevent/Makefile:
-	sed -i 's@\(SUBDIRS = . include\) sample test@\1@' libevent/Makefile.am
 	cp libevent-patch-1 libevent
 	-cd libevent && \
 	 	patch -N -p1 --reject-file=- < libevent-patch-1
@@ -175,6 +174,7 @@ libevent/Makefile:
 			./configure \
 				--host=$(HOST) \
 				--disable-libevent-regress \
+				--disable-samples \
 				--disable-shared
 
 libevent-build-stamp: libevent/Makefile


### PR DESCRIPTION
Follow up for #11

Fixes build for me:

https://travis-ci.org/Unpublished/tor-android/builds/502182296 (search for `error: cannot find -lssl` -> https://travis-ci.org/Unpublished/tor-android/builds/502297720